### PR TITLE
readline: test that disabling history works

### DIFF
--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -32,12 +32,18 @@ function isWarned(emitter) {
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal,
                               historySize: 0 });
   assert.strictEqual(rli.historySize, 0);
+
+  fi.emit('data', 'asdf\n');
+  assert.deepStrictEqual(rli.history, terminal ? [] : undefined);
   rli.close();
 
   // default history size 30
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
   assert.strictEqual(rli.historySize, 30);
+
+  fi.emit('data', 'asdf\n');
+  assert.deepStrictEqual(rli.history, terminal ? ['asdf'] : undefined);
   rli.close();
 
   // sending a full line


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
##### Description of change

<!-- provide a description of the change below this comment -->

Check that when setting `historySize: 0`, the `history` property
of the readline interface is kept empty.
